### PR TITLE
Switch default jgroups_bind_addr to 127.0.0.1

### DIFF
--- a/roles/infinispan/vars/main.yml
+++ b/roles/infinispan/vars/main.yml
@@ -12,7 +12,7 @@ jdg:
   version: "{{ jdg_version if jdg_rhn_id is defined else infinispan_version }}"
   bind_addr: "{{ jdg_bind_address }}"
   port: "{{ jdg_port }}"
-  jgroups_bind_addr: "{{ override_jdg_jgroups_bind_addr | default('127.0.0.1') }}"
+  jgroups_bind_addr: "{{ override_jdg_jgroups_bind_addr | default(ansible_all_ipv4_addresses[0] if ansible_all_ipv4_addresses is defined else '127.0.0.1') }}"
   jgroups_port: "{{ jdg_jgroups_port }}"
   jgroups_relay_port: "{{ jdg_jgroups_relay_port }}"
   config:

--- a/roles/infinispan/vars/main.yml
+++ b/roles/infinispan/vars/main.yml
@@ -12,7 +12,7 @@ jdg:
   version: "{{ jdg_version if jdg_rhn_id is defined else infinispan_version }}"
   bind_addr: "{{ jdg_bind_address }}"
   port: "{{ jdg_port }}"
-  jgroups_bind_addr: "{{ override_jdg_jgroups_bind_addr | default(ansible_all_ipv4_addresses[0]) }}"
+  jgroups_bind_addr: "{{ override_jdg_jgroups_bind_addr | default('127.0.0.1') }}"
   jgroups_port: "{{ jdg_jgroups_port }}"
   jgroups_relay_port: "{{ jdg_jgroups_relay_port }}"
   config:


### PR DESCRIPTION
@guidograzioli As the ansible_all_ipv4_addresses array does not always exists (at least, not in a simple podman container on my machine), the loopback seems to be a saner default... WDYT?