### PR TITLE
feat: statically defined caches

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -10,16 +10,15 @@
         supervisor_password: "itsme"
         infinispan_users:
           - { name: 'testuser', password: 'test', roles: 'observer' }
-    - name: Create test cache
-      include_role:
-        name: ../../roles/infinispan
-        tasks_from: cache.yml
-      vars:
-        jdg_url: "http://{{ jdg.bind_addr }}:{{ jdg.port }}"
-        jdg_username: "supervisor"
-        jdg_password: "itsme"
-        cache:
-          name: test_cache
+        jdg_caches:
+          - cache_xml: >
+              <local-cache name="teststaticcachexml" statistics="true">
+                <encoding media-type="application/x-protostream"/>
+              </local-cache>
+          - cache_config:
+              name: configuredstaticcache
+              template: replicated
+              mode: ASYNC
     - name: "infinispan cache role (xml)"
       include_role:
         name: ../../roles/infinispan_cache

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -8,7 +8,15 @@
       assert:
         that:
           - ansible_facts.services["infinispan.service"]["state"] == "running"
-    - name: "Add entry to test cache"
+    - name: "Check service operational: create test cache via rest"
+      ansible.builtin.uri:
+        url: http://localhost:11222/rest/v2/caches/test_cache
+        method: POST
+        url_username: "supervisor"
+        url_password: "itsme"
+        status_code:
+          - 200
+    - name: "Check service operational: add entry to test cache via rest"
       ansible.builtin.uri:
         url: http://localhost:11222/rest/v2/caches/test_cache/test_entry
         method: POST
@@ -16,7 +24,7 @@
         url_password: "itsme"
         status_code: 
           - 204
-    - name: "Check test cache status"
+    - name: "Check service operational: test cache status via rest"
       ansible.builtin.uri:
         url: http://localhost:11222/rest/v2/caches/test_cache
         url_username: "supervisor"
@@ -25,8 +33,30 @@
     - assert:
         that:
           - test_cache_status.json.size == 1
-        fail_msg: "Test cache error"
-    - name: "Check test cache (xml) status"
+        fail_msg: "infinispan operational error: test cache error"
+    - name: "Check configuration: static test cache (xml) status"
+      ansible.builtin.uri:
+        url: http://localhost:11222/rest/v2/caches/teststaticcachexml
+        url_username: "supervisor"
+        url_password: "itsme"
+      register: test_cache_status
+    - assert:
+        that:
+          - test_cache_status.status == 200
+          - test_cache_status.json.size == 0
+        fail_msg: "infinispan config error: static test cache via XML error"
+    - name: "Check configuration: static test cache (yml) status"
+      ansible.builtin.uri:
+        url: http://localhost:11222/rest/v2/caches/configuredstaticcache
+        url_username: "supervisor"
+        url_password: "itsme"
+      register: test_cache_status
+    - assert:
+        that:
+          - test_cache_status.status == 200
+          - test_cache_status.json.size == 0
+        fail_msg: "infinispan config error: static test cache via YML error"
+    - name: "Check _cache role: test cache (xml) status"
       ansible.builtin.uri:
         url: http://localhost:11222/rest/v2/caches/testcachexml
         url_username: "supervisor"
@@ -36,8 +66,8 @@
         that:
           - test_cache_status.status == 200
           - test_cache_status.json.size == 0
-        fail_msg: "Test cache via XML error"
-    - name: "Check test cache (yml) status"
+        fail_msg: "infinispan_cache error: test cache via XML error"
+    - name: "Check _cache role: test cache (yml) status"
       ansible.builtin.uri:
         url: http://localhost:11222/rest/v2/caches/configuredcache
         url_username: "supervisor"
@@ -47,8 +77,8 @@
         that:
           - test_cache_status.status == 200
           - test_cache_status.json.size == 0
-        fail_msg: "Test cache via YML error"
-    - name: "Check test cache (yml) status"
+        fail_msg: "infinispan_cache error: test cache via YML error"
+    - name: "Check _cache role: test cache (yml) status"
       ansible.builtin.uri:
         url: http://localhost:11222/rest/v2/caches/configuredcachexa
         url_username: "supervisor"
@@ -58,4 +88,4 @@
         that:
           - test_cache_status.status == 200
           - test_cache_status.json.size == 0
-        fail_msg: "Test cache via YML error"        
+        fail_msg: "infinispan_cache error: test cache via YML error"

--- a/roles/infinispan/tasks/main.yml
+++ b/roles/infinispan/tasks/main.yml
@@ -48,6 +48,16 @@
 - name: Include systemd tasks
   include_tasks: tasks/systemd.yml
 
+- name: Parse declarative cache config to cache xml
+  set_fact:
+    #templated_xml_cache: "{{  }}"
+    jdg: "{{ jdg | combine ( { 'static_caches': jdg.static_caches + [item | combine( { 'cache_xml': lookup('template', 'templates/'+item.cache_config.template+'-cache.j2', template_vars=item)|replace('\n', '') }, recursive=True )] } ) }}"
+  loop: "{{ jdg.static_caches|flatten(levels=1) }}"
+  when: item.cache_xml is not defined
+
+- debug:
+    msg: "{{jdg.static_caches}}"
+
 - name: "Ensures {{ jdg.service.name }} configuration is deployed: {{ jdg.config.name }}"
   template:
     src: "{{ jdg.config.template }}"

--- a/roles/infinispan/tasks/main.yml
+++ b/roles/infinispan/tasks/main.yml
@@ -111,7 +111,7 @@
     - jdg_healthcheck
     - jdg.port is defined
 
-- name: Include tasks for keycloak remote caches
+- name: Include tasks to validate keycloak remote caches
   include_tasks: keycloak.yml
   when:
     - jdg_keycloak_cache.enabled

--- a/roles/infinispan/templates/distributed-cache.j2
+++ b/roles/infinispan/templates/distributed-cache.j2
@@ -1,0 +1,61 @@
+<distributed-cache name="{{ cache_config.name }}"
+                   mode="{{ cache_config.mode|default('SYNC') }}"
+                   owners="{{ cache_config.owners|default('2') }}"
+                   {# Unexpected attribute 'capacity-factor' encounteredorg.infinispan.commons.configuration.io.xml.XmlConfigurationReader #}
+                   {# capacity-factor="{{ cache_config.capacity_factor|default('1.0') }}"#}
+                   remote-timeout="{{ cache_config.remote_timeout|default('60000') }}"
+                   statistics="{{ cache_config.statistics|default('false')|lower }}"
+                   segments="{{ cache_config.segments|default('256') }}"
+                   unreliable-return-values="{{ cache_config.unreliable_return_values|default('false')|lower }}">
+
+
+  <encoding media-type="{{ cache_config.encoding|default('application/x-protostream') }}"/>
+
+  <locking isolation="{{ cache_config.isolation|default('REPEATABLE_READ') }}"
+           striping="{{ cache_config.isolation_striping|default('false')|lower }}"
+           acquire-timeout="{{ cache_config.isolation_acquire_timeout|default('10000') }}"
+           concurrency-level="{{ cache_config.isolation_concurrency_level|default('32') }}"/>
+
+  <transaction mode="{{ cache_config.transaction_mode|default('NONE') }}" 
+               locking="{{ cache_config.transaction_locking|default('OPTIMISTIC') }}"/>
+
+  <expiration lifespan="{{ cache_config.expiration_lifespan|default('-1') }}" 
+              max-idle="{{ cache_config.expiration_max_idle|default('-1') }}"
+              interval="{{ cache_config.expiration_interval|default('60000') }}" />
+
+  <memory {% if cache_config.memory_max_count is defined %}max-count="{{ cache_config.memory_max_count|default('-1') }}" {% endif %} 
+          {% if cache_config.memory_max_size is defined and not cache_config.memory_max_count is defined %}max-size="{{ cache_config.memory_max_size|default('') }}" {% endif %} 
+          when-full="{{ cache_config.memory_when_full|default('NONE') }}"
+          storage="{{ cache_config.memory_storage|default('HEAP') }}"/>
+{% if cache_config.indexing is defined and cache_config.indexing %}
+  <indexing enabled="true" 
+            storage="{{ cache_config.indexing_storage|default('filesystem') }}"
+            path="{{ cache_config.indexing_path|default('.') }}" >
+    <indexed-entities>
+{% for entity in cache_config.indexing_entities %}    
+      <indexed-entity>{{ entity }}</indexed-entity>
+{% endfor %}      
+    </indexed-entities>
+  </indexing>
+{% endif %}
+  <partition-handling when-split="{{ cache_config.partition_handling_when_split|default('ALLOW_READ_WRITES') }}" />
+{% if cache_config.persistence is defined and cache_config.persistence %}
+  <persistence passivation="{{ cache_config.persistence_passivation|default('false')|lower }}">
+    <jdbc:string-keyed-jdbc-store fetch-state="false" shared="true" preload="false">
+      <jdbc:data-source jndi-url="{{ cache_config.persistence_jndi_url|default('jdbc/datasource') }}"/>
+      <jdbc:string-keyed-table drop-on-exit="false" create-on-start="true" prefix="{{ cache_config.persistence_prefix|default('DATAGRID') }}">
+        <jdbc:id-column name="id" type="VARCHAR(255)"/>
+        <jdbc:data-column name="datum" type="VARBINARY(4000)"/>
+        <jdbc:timestamp-column name="version" type="BIGINT"/>
+        <jdbc:segment-column name="S" type="INT"/>
+      </jdbc:string-keyed-table>
+    </jdbc:string-keyed-jdbc-store>    
+  </persistence>
+{% endif %}
+{% if cache_config.state_transfer is defined and cache_config.state_transfer %}
+  <state-transfer enabled="true"
+                  timeout="{{ cache_config.state_transfer_timeout|default('240000') }}"
+                  chunk-size="{{ cache_config.state_transfer_chunk_size|default('240000') }}"
+                  await-initial-transfer="{{ cache_config.state_transfer_await_initial_transfer|default('true')|lower }}"/>
+{% endif %}
+</distributed-cache>

--- a/roles/infinispan/templates/infinispan.xml.j2
+++ b/roles/infinispan/templates/infinispan.xml.j2
@@ -62,8 +62,11 @@
       <security>
         <authorization>
           <role name="{{ jdg_supervisor.name }}" permissions="READ WRITE EXEC CREATE"/>
-	    </authorization>
+        </authorization>
       </security>
+{% for cache in jdg.static_caches %}
+{{ cache.cache_xml|default('') }}
+{% endfor %}
     </cache-container>
 
 {% if jdg_keycloak_cache.enabled %}

--- a/roles/infinispan/templates/infinispan.xml.j2
+++ b/roles/infinispan/templates/infinispan.xml.j2
@@ -64,9 +64,9 @@
           <role name="{{ jdg_supervisor.name }}" permissions="READ WRITE EXEC CREATE"/>
         </authorization>
       </security>
-{% for cache in jdg.static_caches %}
+{% for cache in jdg.static_caches %}{% if cache.cache_xml is defined %}
 {{ cache.cache_xml|default('') }}
-{% endfor %}
+{% endif %}{% endfor %}
     </cache-container>
 
 {% if jdg_keycloak_cache.enabled %}

--- a/roles/infinispan/templates/replicated-cache.j2
+++ b/roles/infinispan/templates/replicated-cache.j2
@@ -1,0 +1,57 @@
+<replicated-cache name="{{ cache_config.name }}"
+                  mode="{{ cache_config.mode|default('SYNC') }}"
+                  statistics="{{ cache_config.statistics|default('false')|lower }}"
+                  segments="{{ cache_config.segments|default('256') }}"
+                  unreliable-return-values="{{ cache_config.unreliable_return_values|default('false')|lower }}">
+
+
+  <encoding media-type="{{ cache_config.encoding|default('application/x-protostream') }}"/>
+
+  <locking isolation="{{ cache_config.isolation|default('REPEATABLE_READ') }}"
+           striping="{{ cache_config.isolation_striping|default('false')|lower }}"
+           acquire-timeout="{{ cache_config.isolation_acquire_timeout|default('10000') }}"
+           concurrency-level="{{ cache_config.isolation_concurrency_level|default('32') }}"/>
+
+  <transaction mode="{{ cache_config.transaction_mode|default('NONE') }}" 
+               locking="{{ cache_config.transaction_locking|default('OPTIMISTIC') }}"/>
+
+  <expiration lifespan="{{ cache_config.expiration_lifespan|default('-1') }}" 
+              max-idle="{{ cache_config.expiration_max_idle|default('-1') }}"
+              interval="{{ cache_config.expiration_interval|default('60000') }}" />
+
+  <memory {% if cache_config.memory_max_count is defined %}max-count="{{ cache_config.memory_max_count|default('-1') }}" {% endif %} 
+          {% if cache_config.memory_max_size is defined and not cache_config.memory_max_count is defined %}max-size="{{ cache_config.memory_max_size|default('') }}" {% endif %} 
+          when-full="{{ cache_config.memory_when_full|default('NONE') }}"
+          storage="{{ cache_config.memory_storage|default('HEAP') }}"/>
+{% if cache_config.indexing is defined and cache_config.indexing %}
+  <indexing enabled="true" 
+            storage="{{ cache_config.indexing_storage|default('filesystem') }}"
+            path="{{ cache_config.indexing_path|default('.') }}" >
+    <indexed-entities>
+{% for entity in cache_config.indexing_entities %}    
+      <indexed-entity>{{ entity }}</indexed-entity>
+{% endfor %}      
+    </indexed-entities>
+  </indexing>            
+{% endif %}
+  <partition-handling when-split="{{ cache_config.partition_handling_when_split|default('ALLOW_READ_WRITES') }}" />
+{% if cache_config.persistence is defined and cache_config.persistence %}
+  <persistence passivation="{{ cache_config.persistence_passivation|default('false')|lower }}">
+    <jdbc:string-keyed-jdbc-store fetch-state="false" shared="true" preload="false">
+      <jdbc:data-source jndi-url="{{ cache_config.persistence_jndi_url|default('jdbc/datasource') }}"/>
+      <jdbc:string-keyed-table drop-on-exit="false" create-on-start="true" prefix="{{ cache_config.persistence_prefix|default('DATAGRID') }}">
+        <jdbc:id-column name="id" type="VARCHAR(255)"/>
+        <jdbc:data-column name="datum" type="VARBINARY(4000)"/>
+        <jdbc:timestamp-column name="version" type="BIGINT"/>
+        <jdbc:segment-column name="S" type="INT"/>
+      </jdbc:string-keyed-table>
+    </jdbc:string-keyed-jdbc-store>    
+  </persistence>
+{% endif %}
+{% if cache_config.state_transfer is defined and cache_config.state_transfer %}
+  <state-transfer enabled="true"
+                  timeout="{{ cache_config.state_transfer_timeout|default('240000') }}"
+                  chunk-size="{{ cache_config.state_transfer_chunk_size|default('240000') }}"
+                  await-initial-transfer="{{ cache_config.state_transfer_await_initial_transfer|default('true')|lower }}"/>
+{% endif %}
+</replicated-cache>

--- a/roles/infinispan/vars/main.yml
+++ b/roles/infinispan/vars/main.yml
@@ -39,6 +39,7 @@ jdg:
   service:
     name: "{{ override_jdg_service_name | default('jdg' if jdg_enable else 'infinispan') }}"
   users: "{{ [ jdg_supervisor ] + infinispan_users }}"
+  static_caches: "{{ jdg_caches }}"
 
 jdg_jgroups_jdbc:
   mariadb:


### PR DESCRIPTION
In main infinispan role, support `jdg_caches` variable as list of configurations to be statically
included in infinispam.xml, using same syntax as for infinispan_cache role