### PR TITLE
New `jdg_configure_firewalld` bool parameter controls firewall config

### DIFF
--- a/roles/infinispan/README.md
+++ b/roles/infinispan/README.md
@@ -37,7 +37,7 @@ Role Defaults
 |`jdg_keystore_key_password`| Key passphrase for TLS server identity | `''`|
 |`infinispan_keycloak_caches`| Creates remote caches for keycloak | `False` |
 |`jdg_jvm_package`| RHEL java package runtime | `java-11-openjdk-headless` |
-|`jdg_enable`|Install Red Hat DataGrid when true| `True` when credentials available, `False` otherwise|
+|`jdg_enable`|Install Red Hat DataGrid when true| `True` when credentials available, `False` otherwise |
 
 
 * Download and install defaults
@@ -61,6 +61,7 @@ Role Defaults
 |`jdg_caches`| List of cache definitions to configure statically | `[]` |
 |`infinispan_users`| List of users to create | `[]` |
 |`rest_cache_api_path`| Path of infinispan rest api | `/rest/v2/caches/` |
+|`jdg_configure_firewalld`| Ensure firewalld is running and configure infinispan/jdg ports | `False` |
 
 
 Role Variables

--- a/roles/infinispan/defaults/main.yml
+++ b/roles/infinispan/defaults/main.yml
@@ -30,6 +30,7 @@ jdg_service_user: jdg
 jdg_service_group: jdg
 jdg_port_offset: 0
 jdg_jvm_package: java-11-openjdk-headless
+jdg_configure_firewalld: False
 
 # flag to enable protocol encryption
 jdg_default_realm_tls: False

--- a/roles/infinispan/meta/argument_specs.yml
+++ b/roles/infinispan/meta/argument_specs.yml
@@ -16,6 +16,11 @@ argument_specs:
                 default: "/opt/infinispan/redhat-datagrid-{{ jdg_version }}-server/"
                 description: "Target extracted installation"
                 type: "str"
+            jdg_configure_firewalld:
+                # line 33 of infinispan/defaults/main.yml
+                default: false
+                description: "Ensure firewalld is running and configure infinispan/jdg ports"
+                type: "bool"
             jdg_bundle:
                 # line 5 of infinispan/defaults/main.yml
                 default: "redhat-datagrid-{{ jdg_version }}-server.zip"

--- a/roles/infinispan/tasks/main.yml
+++ b/roles/infinispan/tasks/main.yml
@@ -25,9 +25,19 @@
 
 - name: Include prerequisite tasks
   ansible.builtin.include_tasks: prereqs.yml
+  tags:
+    - prereqs
+
+- name: Include firewall config tasks
+  ansible.builtin.include_tasks: firewalld.yml
+  when: jdg_configure_firewalld
+  tags:
+    - firewall
 
 - name: Include install tasks
   ansible.builtin.include_tasks: tasks/install.yml
+  tags:
+    - install
 
 - name: Install directory
   ansible.builtin.debug:
@@ -35,6 +45,8 @@
 
 - name: Include systemd tasks
   ansible.builtin.include_tasks: tasks/systemd.yml
+  tags:
+    - systemd
 
 - name: "Ensure {{ jdg.service.name }} configuration is deployed: {{ jdg.config.name }}"
   ansible.builtin.template:


### PR DESCRIPTION
Default is false; this change lets avoiding to `include_role/tasks_from: firewalld.yml` for general firewall config, by setting the value to true instead.