### PR TITLE
Feature/mssql

### DIFF
--- a/roles/infinispan/README.md
+++ b/roles/infinispan/README.md
@@ -86,7 +86,7 @@ The following are _required_ when `infinispan_jgroups_jdbcping` is enabled:
 
 | Variable | Description | Default |
 |:---------|:------------|:--------|
-|`infinispan_jdbc_engine`| backend database engine (values: `['mariadb','postgres']`) | `mariadb` |
+| `infinispan_jdbc_engine`         | backend database engine (values: `['mariadb','postgres','sqlserver']`) | `mariadb`                                |
 |`infinispan_jdbc_driver_version`| driver version to download | `2.7.4` |
 |`infinispan_jdbc_url`| URL for jdbc connection | `jdbc:mariadb://localhost:3306/keycloak` |
 |`infinispan_jdbc_user`| username for jdbc connection | `keycloak-user` |

--- a/roles/infinispan/tasks/install.yml
+++ b/roles/infinispan/tasks/install.yml
@@ -4,12 +4,14 @@
     name: "{{ infinispan.group.name }}"
     state: present
     gid: "{{ infinispan.group.id | default(omit) }}"
+  become: yes
 
 - name: "Create user {{ infinispan.user.name }}"
   ansible.builtin.user:
     name: "{{ infinispan.user.name }}"
     state: present
     uid: "{{ infinispan.user.id | default(omit) }}"
+  become: yes
 
 - name: "Create download directory"
   ansible.builtin.file:
@@ -18,6 +20,7 @@
     owner: "{{ infinispan.user.name }}"
     group: "{{ infinispan.group.name }}"
     mode: 0750
+  become: yes
 
 ## check remote archive
 - name: Set download archive path
@@ -28,6 +31,7 @@
   ansible.builtin.stat:
     path: "{{ archive }}"
   register: archive_path
+  become: yes
 
 - name: Check local download archive path
   ansible.builtin.stat:
@@ -77,7 +81,7 @@
       delegate_to: localhost
       run_once: yes
 
-    - name: Download AMQ Broker
+    - name: Download Data Grid
       middleware_automation.common.product_download:
         client_id: "{{ rhn_username }}"
         client_secret: "{{ rhn_password }}"
@@ -94,6 +98,7 @@
     mode: 0644
   delegate_to: localhost
   when:
+    - jdg_download_url is defined and jdg_download_url | length > 0
     - archive_path is defined
     - archive_path.stat is defined
     - not archive_path.stat.exists
@@ -128,10 +133,10 @@
   register: path_to_workdir
   become: yes
 
-- name: "Create target directory {{ infinispan.installation_path | dirname | dirname }}"
+- name: "Create target directory {{ infinispan.installation_path | dirname }}"
   ansible.builtin.file:
     state: directory
-    path: "{{ infinispan.installation_path | dirname | dirname }}"
+    path: "{{ infinispan.installation_path | dirname }}"
     owner: "{{ infinispan.user.name }}"
     group: "{{ infinispan.group.name }}"
     mode: 0750

--- a/roles/infinispan/tasks/jdg_user.yml
+++ b/roles/infinispan/tasks/jdg_user.yml
@@ -15,6 +15,7 @@
     mode: 0644
   notify:
     - restart infinispan
+  become: yes
 
 - name: "Ensure {{ infinispan.config.groups }} exists"
   ansible.builtin.template:
@@ -25,3 +26,4 @@
     mode: 0644
   notify:
     - restart infinispan
+  become: yes

--- a/roles/infinispan/tasks/main.yml
+++ b/roles/infinispan/tasks/main.yml
@@ -67,6 +67,7 @@
     jdg_rpm_java_home: "{{ rpm_java_home.stdout }}"
   notify:
     - restart infinispan
+  become: yes
 
 - name: "Get xsd schema versions"
   ansible.builtin.find:
@@ -74,6 +75,7 @@
     use_regex: yes
     patterns: ['^.*-server-[0-9.]*[.]xsd$']
   register: server_schema
+  become: yes
 
 - name: "Set fetched schema version for template"
   ansible.builtin.set_fact:
@@ -89,6 +91,7 @@
     backup: yes
   notify:
     - restart infinispan
+  become: yes
 
 - name: "Ensure {{ infinispan.service.name }} log4j2 configuration is deployed"
   ansible.builtin.template:
@@ -100,6 +103,7 @@
     backup: yes
   notify:
     - restart infinispan
+  become: yes
 
 - name: Download database driver jar to target
   ansible.builtin.get_url:
@@ -110,6 +114,7 @@
     mode: 0644
   when:
     - infinispan_jgroups_jdbcping
+  become: yes
 
 - name: Include users tasks
   ansible.builtin.include_tasks: jdg_user.yml
@@ -132,3 +137,4 @@
     state: link
     src: "{{ infinispan.home }}/server/log"
     dest: "/var/log/infinispan{{ '-' + infinispan_nodename if infinispan_nodename != inventory_hostname else '' }}"
+  become: yes

--- a/roles/infinispan/tasks/restart.yml
+++ b/roles/infinispan/tasks/restart.yml
@@ -5,10 +5,12 @@
   - name: "Restart service"
     ansible.builtin.systemd:
       name: "{{ infinispan.service.unit_file }}"
-      state: restarted  
+      state: restarted
+    become: yes
   - name: "Wait for used port to be open"
     ansible.builtin.wait_for:
       port: "{{ infinispan.port }}"
       delay: 0
     when:
       - infinispan_healthcheck
+    become: yes

--- a/roles/infinispan/tasks/start.yml
+++ b/roles/infinispan/tasks/start.yml
@@ -6,9 +6,11 @@
       name: "{{ infinispan.service.unit_file }}"
       state: started
       enabled: yes
+    become: yes
   - name: "Wait for used port to be open"
     ansible.builtin.wait_for:
       port: "{{ infinispan.port }}"
       delay: 0
     when:
       - infinispan_healthcheck
+    become: yes

--- a/roles/infinispan/templates/infinispan.xml.j2
+++ b/roles/infinispan/templates/infinispan.xml.j2
@@ -161,7 +161,7 @@
                      />
                   </ssl>
                </server-identities>
-{% endif %}              
+{% endif %}
                <properties-realm groups-attribute="Roles">
                   <user-properties path="users.properties"/>
                   <group-properties path="groups.properties"/>

--- a/roles/infinispan/vars/main.yml
+++ b/roles/infinispan/vars/main.yml
@@ -85,6 +85,25 @@ infinispan_jgroups_jdbc:
         updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         ping_data BYTEA,
         constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))
+  sqlserver:
+    enabled: "{{ infinispan_jgroups_jdbcping and infinispan_jdbc_engine == 'sqlserver' }}"
+    driver_class: com.microsoft.sqlserver.jdbc.SQLServerDriver
+    driver_version: "{{ infinispan_jdbc_driver_version | default('9.2.0') }}"
+    driver_jar_filename: "mssql-java-client-{{ infinispan_jdbc_driver_version }}.jar"
+    driver_jar_url: "https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/{{ infinispan_jdbc_driver_version }}.jre11/mssql-jdbc-{{ infinispan_jdbc_driver_version }}.jre11.jar" # e.g., https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/12.2.0.jre11/mssql-jdbc-12.2.0.jre11.jar
+    connection_url: "{{ infinispan_jdbc_url | default('jdbc:postgresql://localhost:5432/keycloak') }}"
+    db_user: "{{ infinispan_jdbc_user }}"
+    db_password: "{{ infinispan_jdbc_pass }}"
+    initialize_sql: >
+      IF  NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[JGROUPSPING]') AND type in (N'U'))
+      BEGIN
+        CREATE TABLE JGROUPSPING (
+          own_addr varchar(200) NOT NULL,
+          cluster_name varchar(200) NOT NULL,
+          updated DATETIME2 DEFAULT SYSUTCDATETIME(),
+          ping_data varbinary(5000) DEFAULT NULL,
+          PRIMARY KEY (own_addr, cluster_name))
+      END
 
 infinispan_keycloak_cache:
   enabled: "{{ infinispan_keycloak_caches }}"


### PR DESCRIPTION
Initially this endeavor started out by adding MSSQL support, but it escalated quite quickly:
* Adds sqlserver JDBC support
* Improved `become: yes` handling (tested with JDG only)
* Just like its [keycloak pendant](https://github.com/ansible-middleware/keycloak/pull/81) it adds systemd restart behavior by default

I think that the changes are small enough to keep it in a single PR, but let me know if you want to have it split.