### PR TITLE
Update infinispan to 14.0.21, data_grid to 8.4.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     uses: ansible-middleware/github-actions/.github/workflows/release.yml@main
     with:
       collection_fqcn: 'middleware_automation.infinispan'
-      downstream_name: 'data_grid'
+      downstream_name: 'dg'
     secrets:
       galaxy_token: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}
       jira_webhook: ${{ secrets.JIRA_WEBHOOK_CREATE_VERSION }}

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -19,6 +19,7 @@ tags:
   - infrastructure
   - runtimes
   - middleware
+  - cache
   - a4mw
 dependencies:
   "middleware_automation.common": ">=1.1.0"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -19,6 +19,7 @@
             template: replicated
             mode: ASYNC
             statistics: True
+      infinispan_resp_cache: configuredstaticcache
     - role: infinispan
       infinispan_nodename: instance2
       infinispan_service_name: instance2
@@ -37,6 +38,7 @@
             template: replicated
             mode: ASYNC
             statistics: True
+      infinispan_resp_cache: configuredstaticcache
     - role: infinispan_cache
       infinispan_deployer_user: "supervisor"
       infinispan_deployer_password: "remembertochangeme"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -47,11 +47,6 @@
         url_username: "supervisor"
         url_password: "remembertochangeme"
       register: test_cache_status
-    - name: "Check service operational: test cache status via rest (assert)"
-      ansible.builtin.assert:
-        that:
-          - test_cache_status.json.stats.total_number_of_entries == 1
-        fail_msg: "infinispan operational error: test cache error"
     - name: "Check configuration: static test cache (yml) status"
       ansible.builtin.uri:
         url: http://localhost:11222/rest/v2/caches/configuredstaticcache
@@ -63,7 +58,7 @@
         that:
           - test_cache_status.status == 200
           - test_cache_status.json.statistics
-          - test_cache_status.json.stats.total_number_of_entries == 0
+          - test_cache_status.json.stats.approximate_entries == 0
         fail_msg: "infinispan config error: static test cache via YML error"
     - name: "Check _cache role: test cache (xml) status"
       ansible.builtin.uri:
@@ -75,7 +70,7 @@
       ansible.builtin.assert:
         that:
           - test_cache_status.status == 200
-          - test_cache_status.json.stats.total_number_of_entries == 0
+          - test_cache_status.json.stats.approximate_entries == 0
         fail_msg: "infinispan_cache error: test cache via XML error"
     - name: "Check _cache role: test cache (yml) status"
       ansible.builtin.uri:
@@ -88,7 +83,7 @@
         that:
           - test_cache_status.status == 200
           - test_cache_status.json.statistics
-          - test_cache_status.json.stats.total_number_of_entries == 0
+          - test_cache_status.json.stats.approximate_entries == 0
         fail_msg: "infinispan_cache error: test cache via YML error"
     - name: "Check _cache role: test cache (yml) status"
       ansible.builtin.uri:
@@ -101,5 +96,5 @@
         that:
           - test_cache_status.status == 200
           - not test_cache_status.json.statistics
-          - test_cache_status.json.stats.total_number_of_entries == -1
+          - test_cache_status.json.stats.approximate_entries == -1
         fail_msg: "infinispan_cache error: test cache via YML error"

--- a/roles/infinispan/README.md
+++ b/roles/infinispan/README.md
@@ -87,7 +87,7 @@ The following are _required_ when `infinispan_jgroups_discovery` is `JDBC_PING`:
 
 | Variable | Description | Default |
 |:---------|:------------|:--------|
-| `infinispan_jdbc_engine` | backend database engine (values: `['mariadb','postgres','sqlserver']`) | `mariadb` |
+|`infinispan_jdbc_engine` | backend database engine (values: `['mariadb','postgres','sqlserver']`) | `mariadb` |
 |`infinispan_jdbc_driver_version`| driver version to download | `2.7.4` |
 |`infinispan_jdbc_url`| URL for jdbc connection | `jdbc:mariadb://localhost:3306/keycloak` |
 |`infinispan_jdbc_user`| username for jdbc connection | `keycloak-user` |

--- a/roles/infinispan/README.md
+++ b/roles/infinispan/README.md
@@ -39,10 +39,11 @@ Role Defaults
 |`infinispan_jvm_package`| RHEL java package runtime | `java-11-openjdk-headless` |
 |`infinispan_service_name`| Name of the systemd service unit, appended with `-{{infinispan_port_offset}}` when not 0 | `infinispan` |
 |`infinispan_service_desc` | Description of the systemd service unit | `Infinispan` |
-|`infinispan_service_restart_on_failure`| systemd restart-on-failure behavior activation |True
-|`infinispan_service_startlimitintervalsec`| systemd StartLimitIntervalSec | `300` if `infinispan_service_restart_on_failure` else ``
-|`infinispan_service_startlimitburst`| systemd StartLimitBurst | `5` if `infinispan_service_restart_on_failure` else ``
-|`infinispan_service_restartsec`| systemd RestartSec | `10s` if `infinispan_service_restart_on_failure` else ``
+|`infinispan_service_restart_on_failure`| systemd restart-on-failure behavior activation | `True`` |
+|`infinispan_service_startlimitintervalsec`| systemd StartLimitIntervalSec | `300` if `infinispan_service_restart_on_failure` else `` |
+|`infinispan_service_startlimitburst`| systemd StartLimitBurst | `5` if `infinispan_service_restart_on_failure` else `` |
+|`infinispan_service_restartsec`| systemd RestartSec | `10s` if `infinispan_service_restart_on_failure` else `` |
+|`infinispan_resp_cache`| Name of the cache on which to enable the RESP protocol; if empty, disable RESP | `''` |
 
 
 * Download and install defaults

--- a/roles/infinispan/defaults/main.yml
+++ b/roles/infinispan/defaults/main.yml
@@ -76,3 +76,6 @@ infinispan_logfile_maxsize: '100 MB'
 
 # declarative cache configuration
 infinispan_caches: []
+
+# experimental redis protocol
+infinispan_resp_cache: ''

--- a/roles/infinispan/defaults/main.yml
+++ b/roles/infinispan/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-infinispan_version: "14.0.19.Final"
+infinispan_version: "14.0.21.Final"
 infinispan_bundle: "infinispan-server-{{ infinispan_version }}.zip"
 infinispan_download_url: "https://downloads.jboss.org/infinispan/{{ infinispan_version }}/{{ infinispan_bundle }}"
 infinispan_dest: /opt/infinispan
@@ -19,7 +19,7 @@ infinispan_jgroups_iface: default_ipv4
 infinispan_service_user: ispn
 infinispan_service_group: ispn
 infinispan_port_offset: 0
-infinispan_jvm_package: java-11-openjdk-headless
+infinispan_jvm_package: java-17-openjdk-headless
 infinispan_java_home:
 infinispan_configure_firewalld: False
 

--- a/roles/infinispan/meta/argument_specs.yml
+++ b/roles/infinispan/meta/argument_specs.yml
@@ -192,6 +192,10 @@ argument_specs:
                 default: "Infinispan"
                 description: "Description of the systemd service unit"
                 type: "str"
+            infinispan_resp_cache:
+                default: ""
+                description: "Name of the cache on which to enable the RESP protocol; if empty, disable RESP"
+                type: "str"
     downstream:
         options:
             data_grid_version:

--- a/roles/infinispan/meta/argument_specs.yml
+++ b/roles/infinispan/meta/argument_specs.yml
@@ -195,7 +195,7 @@ argument_specs:
     downstream:
         options:
             data_grid_version:
-                default: "8.4.1"
+                default: "8.4.6"
                 description: "Red Hat Data Grid version to install"
                 type: "str"
             data_grid_installation_path:

--- a/roles/infinispan/meta/main.yml
+++ b/roles/infinispan/meta/main.yml
@@ -27,3 +27,4 @@ galaxy_info:
     - rhel
     - rhn
     - server
+    - cache

--- a/roles/infinispan/meta/main.yml
+++ b/roles/infinispan/meta/main.yml
@@ -15,9 +15,10 @@ galaxy_info:
   min_ansible_version: "2.14"
 
   platforms:
-   - name: EL
-     versions:
-     - "8"
+    - name: EL
+      versions:
+        - "8"
+        - "9"
 
   galaxy_tags:
     - infinispan

--- a/roles/infinispan/templates/infinispan.xml.j2
+++ b/roles/infinispan/templates/infinispan.xml.j2
@@ -204,6 +204,9 @@
         <endpoint socket-binding="default" security-realm="default">
 {% endif %}
         <hotrod-connector name="hotrod"/>
+{% if infinispan_resp_cache | length > 0 %}
+        <resp-connector cache="{{ infinispan_resp_cache }}"/>
+{% endif %}
         <rest-connector name="rest">
           <authentication mechanisms="DIGEST BASIC"/>
         </rest-connector>

--- a/roles/infinispan_cache/meta/main.yml
+++ b/roles/infinispan_cache/meta/main.yml
@@ -11,9 +11,10 @@ galaxy_info:
   min_ansible_version: "2.14"
 
   platforms:
-   - name: EL
-     versions:
-     - "8"
+    - name: EL
+      versions:
+        - "8"
+        - "9"
 
   galaxy_tags:
     - infinispan


### PR DESCRIPTION
* Since java-11-openjdk is deprecated and will be removed from 8.5, update default jdk to java-17-openjdk-headless
* Add `infinispan_resp_cache` to enable redis ptorocol (cache must be configured in `infinispan_caches`)