### PR TITLE
Add parameter `infinispan_jgroups_cluster_nodes` to explicitly set the node connection config

### DIFF
--- a/roles/infinispan/README.md
+++ b/roles/infinispan/README.md
@@ -16,11 +16,6 @@ Role Defaults
 |`infinispan_jgroups_relay_port`| Alternate port for the jgroups relaying cluster | `7801` |
 |`infinispan_port_offset`| Optional port offset for colocated installations | `0` |
 |`infinispan_nodename`| Instance name for service (ie. cluster node identifier) | `{{ inventory_hostname }}` |
-|`infinispan_jgroups_relay`| Enable cross-DC relaying | `False` |
-|`infinispan_jgroups_relay_sites`| List of site names for cross-DC relaying | `[]` |
-|`infinispan_jgroups_relay_site`| Site the inventory host is in when cross-DC is enabled | `''` |
-|`infinispan_jgroups_discovery`| Clustering discovery protocol, value from [`PING`,`TCPPING`,`JDBC_PING`] | `` |
-|`infinispan_jgroups_iface` | The NIC name to be used for cluster IPv4 addresses (ie. 'eth0') | `default_ipv4` |
 |`infinispan_keycloak_persistence`| Enable persitence datasource for keycloak caches | `False` |
 |`infinispan_service_user`| Posix account for the service installation | `ispn` |
 |`infinispan_service_group`| Posix group for the service installation | `ispn` |
@@ -44,6 +39,40 @@ Role Defaults
 |`infinispan_service_startlimitburst`| systemd StartLimitBurst | `5` if `infinispan_service_restart_on_failure` else `` |
 |`infinispan_service_restartsec`| systemd RestartSec | `10s` if `infinispan_service_restart_on_failure` else `` |
 |`infinispan_resp_cache`| Name of the cache on which to enable the RESP protocol; if empty, disable RESP | `''` |
+
+
+* Cluster configuration
+
+| Variable | Description | Default |
+|:---------|:------------|:--------|
+|`infinispan_jgroups_relay`| Enable cross-DC relaying | `False` |
+|`infinispan_jgroups_relay_sites`| List of site names for cross-DC relaying | `[]` |
+|`infinispan_jgroups_relay_site`| Site the inventory host is in when cross-DC is enabled | `''` |
+|`infinispan_jgroups_discovery`| Clustering discovery protocol, value from [`PING`,`TCPPING`,`JDBC_PING`] | `` |
+|`infinispan_jgroups_iface` | The NIC name to be used for cluster IPv4 addresses (ie. 'eth0') | `default_ipv4` |
+|`infinispan_jgroups_cluster_nodes`| List of node definitions for jgroups cluster, read below for the format | `[]` |
+
+The `infinispan_jgroups_cluster_nodes` parameter, when empty, tell the collection to geenrate the list from the hosts variables in `ansible_play_hosts`;
+otherwise, it can be passed-in using the following dictionary format:
+
+```yaml
+infinispan_jgroups_cluster_nodes:
+  - address: 10.0.0.175
+    inventory_host: '10.0.0.175[7800]'
+    name: us-east-2-datagrid-1
+    port: 7800
+    site: us-east-2
+    value: 'tcp://10.0.0.175:7800'
+  - address: 10.0.0.179
+    inventory_host: "10.0.0.179[7800]"
+    name: us-east-2-datagrid-2
+    port: 7800
+    site: us-east-2
+    value: 'tcp://10.0.0.179:7800'
+```
+
+where `address`, `port`, and `inventory_host` are connection details; `name` is the name of the host in the cluster, `site` is the name of the cluster in the xsite configuration,
+and `value` is explicit connection string.
 
 
 * Download and install defaults

--- a/roles/infinispan/defaults/main.yml
+++ b/roles/infinispan/defaults/main.yml
@@ -46,6 +46,7 @@ infinispan_jgroups_relay: False
 infinispan_jgroups_relay_sites: []
 # site (cluster) this node belongs to, all nodes belong to default if not overridden
 infinispan_jgroups_relay_site: ''
+infinispan_jgroups_cluster_nodes: []
 
 # flag to enable keycloak integration
 infinispan_keycloak_caches: False

--- a/roles/infinispan/meta/argument_specs.yml
+++ b/roles/infinispan/meta/argument_specs.yml
@@ -196,6 +196,10 @@ argument_specs:
                 default: ""
                 description: "Name of the cache on which to enable the RESP protocol; if empty, disable RESP"
                 type: "str"
+            infinispan_jgroups_cluster_nodes:
+                description: "List of node definitions for jgroups cluster, each node is a dictionary"
+                default: []
+                type: "list"
     downstream:
         options:
             data_grid_version:

--- a/roles/infinispan/tasks/main.yml
+++ b/roles/infinispan/tasks/main.yml
@@ -66,6 +66,14 @@
     host_port: "{{ (((infinispan_jgroups_port | int + infinispan_port_offset | int) | abs) | string) }}"
     host_site: "{{ hostvars[item]['infinispan_jgroups_relay_site'] | default(infinispan_jgroups_relay_site) if infinispan_jgroups_relay else '' }}"
   when:
+    - infinispan_jgroups_cluster_nodes | length == 0
+    - infinispan_jgroups_discovery == 'TCPPING'
+
+- name: Create infinispan cluster node members
+  ansible.builtin.set_fact:
+    infinispan_cluster_nodes: "{{ infinispan_jgroups_cluster_nodes }}"
+  when:
+    - infinispan_jgroups_cluster_nodes | length > 0
     - infinispan_jgroups_discovery == 'TCPPING'
 
 - name: Determine JAVA_HOME for selected JVM RPM

--- a/roles/infinispan/templates/infinispan.xml.j2
+++ b/roles/infinispan/templates/infinispan.xml.j2
@@ -58,9 +58,7 @@
                 can_forward_local_cluster="true" relay_multicasts="false" async_relay_creation="true" />
             <remote-sites default-stack="datagridrelay">
 {% for site in infinispan_jgroups_relay_sites %}
-{% if site != infinispan_jgroups_relay_site %}
                 <remote-site name="{{ site }}"/>
-{% endif %}
 {% endfor %}
             </remote-sites>
         </stack>

--- a/roles/infinispan/templates/infinispan.xml.j2
+++ b/roles/infinispan/templates/infinispan.xml.j2
@@ -45,9 +45,9 @@
                 select_all_pingdata_sql="SELECT ping_data FROM JGROUPSPING WHERE cluster_name=?" />
 {% endif %}
 {% if infinispan_jgroups_discovery == 'TCPPING' %}
-            <!-- TCP local cluster with TCPPING discovery -->
+            <!-- TCP RELAY cluster with TCPPING discovery -->
             <TCPPING  stack.combine="REPLACE" stack.position="MPING"
-                  initial_hosts="{{ infinispan_cluster_nodes | selectattr('site', 'equalto', infinispan_jgroups_relay_site) | map(attribute='inventory_host') | join (',') }}"
+                  initial_hosts="{{ infinispan_cluster_nodes | map(attribute='inventory_host') | join (',') }}"
                   port_range="1" />
             <pbcast.GMS join_timeout="3000" />
 {% endif %}


### PR DESCRIPTION
When `infinispan_jgroups_discovery` is `TCPPING`, the cluster initial node list is pre-configured automatically using the hostvars included in the `ansible_play_hosts`. This new parameter allows to override the behaviour, explicitly setting all needed jgroups parameters. 

| Variable | Description | Default |
|:---------|:------------|:--------|
|`infinispan_jgroups_cluster_nodes`| List of node definitions for jgroups cluster, read below for the format | `[]` |

The `infinispan_jgroups_cluster_nodes` parameter, when empty, tell the collection to geenrate the list from the hosts variables in `ansible_play_hosts`;
otherwise, it can be passed-in using the following dictionary format:

```yaml
infinispan_jgroups_cluster_nodes:
  - address: 10.0.0.175
    inventory_host: '10.0.0.175[7800]'
    name: us-east-2-datagrid-1
    port: 7800
    site: us-east-2
    value: 'tcp://10.0.0.175:7800'
  - address: 10.0.0.179
    inventory_host: "10.0.0.179[7800]"
    name: us-east-2-datagrid-2
    port: 7800
    site: us-east-2
    value: 'tcp://10.0.0.179:7800'
```

where `address`, `port`, and `inventory_host` are connection details; `name` is the name of the host in the cluster, `site` is the name of the cluster in the xsite configuration,
and `value` is explicit connection string.
