### PR TITLE
Standardize .gitignore and .ansible-lint configuration

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,6 @@
 # .ansible-lint
+profile: production
+
 exclude_paths:
   - .cache/
   - .github/

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ inventory
 changelogs/.plugin-cache.yaml
 molecule/vector-search/test-app/target/
 molecule/vector-search/files/*.jar
+.ansible

--- a/README.md
+++ b/README.md
@@ -117,4 +117,4 @@ For details on changes between versions, please see the [CHANGELOG](https://gith
 
 Apache License v2.0 or later
 
-See [LICENSE](LICENSE) to view the full text.
+See [LICENSE](https://github.com/ansible-middleware/infinispan/blob/main/LICENSE) to view the full text.


### PR DESCRIPTION
- Add .ansible to .gitignore to exclude Ansible runtime artifacts
- Add profile: production to .ansible-lint for production-level linting