### PR TITLE
Remove changelogs/fragments dotfile breaking sanity tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ docs/_build/
 *.retry
 inventory
 changelogs/.plugin-cache.yaml
+changelogs/fragments/*.yml
+changelogs/fragments/*.yaml
 molecule/vector-search/test-app/target/
 molecule/vector-search/files/*.jar
 .ansible

--- a/changelogs/fragments/.gitignore
+++ b/changelogs/fragments/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
Delete changelogs/fragments/.gitignore dotfile that causes ansible sanity test failure and add fragment patterns to root .gitignore.

[AMW-604](https://redhat.atlassian.net/browse/AMW-604)